### PR TITLE
Use parskip package

### DIFF
--- a/tex/probl-base.sty
+++ b/tex/probl-base.sty
@@ -44,6 +44,9 @@
 % Microtypography
 \RequirePackage{microtype}
 
+% Parskip
+\RequirePackage[skip=0pt plus 2pt, parfill]{parskip}
+
 %% Units
 %% ----------------------------------------------------------------------
 \RequirePackage{siunitx}


### PR DESCRIPTION
Use `parskip` package to kill paragraph indentation.